### PR TITLE
D9 readiness

### DIFF
--- a/component.info.yml
+++ b/component.info.yml
@@ -2,4 +2,4 @@ name: Component
 type: module
 description: 'Easily add JS components to Drupal as blocks, with only a single yml file.'
 package: Component
-core: '8.x'
+core_version_requirement: ^8 || ^9

--- a/src/Plugin/Derivative/ComponentBlockDeriver.php
+++ b/src/Plugin/Derivative/ComponentBlockDeriver.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\component\Plugin\Derivative;
 
+use Drupal\Component\Plugin\Derivative\DeriverBase;
 use Drupal\Core\Plugin\Context\ContextDefinition;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\component\ComponentDiscoveryInterface;


### PR DESCRIPTION
Line src/Plugin/Derivative/ComponentBlockDeriver.php
-------------------------------------------------------------------------------------
14 Class Drupal\component\Plugin\Derivative\DeriverBase not found and could not be autoloaded.
-------------------------------------------------------------------------------------

-------------------------------------------------------------------------------------
Line component.info.yml
-------------------------------------------------------------------------------------
0 Add <code>core_version_requirement: ^8 || ^9</code> to component.info.yml to designate that the module is compatible with Drupal 9. See https://www.drupal.org/node/3070687.
-------------------------------------------------------------------------------------